### PR TITLE
Change: Freeze account data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Upgrade notes:**
 
+- **Changed**: Change: Freeze account data [#5](https://github.com/CodiTramuntana/decidim-erc-app/pull/5)
 - **Added**: Add: amendments customizations [#1](https://github.com/CodiTramuntana/decidim-erc-app/pull/1)
 
 ## Previous changes

--- a/app/views/decidim/account/show.html.erb
+++ b/app/views/decidim/account/show.html.erb
@@ -1,0 +1,29 @@
+<div class="row">
+  <%= decidim_form_for(@account, url: account_path, method: :put, html: { autocomplete: "nope" }) do |f| %>
+    <input autocomplete="off" name="hidden" type="password" style="display:none;">
+    <div class="columns large-4">
+      <%= f.upload :avatar %>
+    </div>
+
+    <div class="columns large-8 end">
+      <!-- Overwriting this view to make fields readonly -->
+      <%= f.text_field :name, readonly: true %>
+      <%= f.text_field :nickname, readonly: true %>
+      <%= f.email_field :email, readonly: true %>
+      <!-- /Overwriting this view to make fields readonly -->
+
+      <% if @account.errors[:password].any? || @account.errors[:password_confirmation].any? %>
+        <%= render partial: "password_fields", locals: { form: f } %>
+      <% else %>
+        <p>
+          <a data-toggle="passwordChange" class="change-password"><%= t ".change_password" %></a>
+        </p>
+        <div id="passwordChange" class="toggle-show" data-toggler=".is-expanded">
+          <%= render partial: "password_fields", locals: { form: f } %>
+        </div>
+      <% end %>
+
+      <%= f.submit t(".update_account"), disable_with: true %>
+    <% end %>
+  </div>
+</div>

--- a/spec/system/account_spec.rb
+++ b/spec/system/account_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Account", type: :system do
+  let(:user) { create(:user, :confirmed, password: password, password_confirmation: password) }
+  let(:password) { "dqCFgjfDbC7dPbrv" }
+  let(:organization) { user.organization }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+  end
+
+  context "when on the account page" do
+    before do
+      visit decidim.account_path
+    end
+
+    it "does not allow to edit personal data" do
+      expect(page).to have_field(:user_name, readonly: true)
+      expect(page).to have_field(:user_nickname, readonly: true)
+      expect(page).to have_field(:user_email, readonly: true)
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
> Quedem que en cap moment es podran modificar les dades dins de la plataforma Decidim [...]
Això també afecta a la Configuració d'usuari. 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)
![account_data](https://user-images.githubusercontent.com/40306853/66560192-23fd5d80-eb57-11e9-87ea-7c2881e0a359.png)