### PR TITLE
Update: Decidim::Erc::CrmAuthenticable initializer

### DIFF
--- a/config/initializers/decidim_erc_crm_authenticable.rb
+++ b/config/initializers/decidim_erc_crm_authenticable.rb
@@ -2,11 +2,11 @@
 
 # https://github.com/CodiTramuntana/decidim-erc-crm_authenticable/blob/master/lib/decidim/erc/crm_authenticable.rb
 Decidim::Erc::CrmAuthenticable::CIVICRM_COMARCAL_EXCEPTIONS = %w(
+  4
   5723
   5724
   5727
   5729
-  5730
 ).freeze
 filepath = Rails.root.join("config", "civi_crm", "decidim_scopes_mapping.yml")
 Decidim::Erc::CrmAuthenticable::SCOPE_CODES = YAML.load_file(filepath).freeze if File.exist?(filepath)


### PR DESCRIPTION
Abans hi havia dos contactes de tipus Organització i subtipus Comarcal repetits:

> (contact_id => display_name) 
> '4': Vallès Oriental (comarcal)
> '5730': Vallès Oriental (comarcal)

Ens van informar que el bo era el 5730, però l'han esborrat.