### PR TITLE
Reconfigure email settings

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -93,7 +93,6 @@ Rails.application.configure do
     domain: Rails.application.secrets.smtp_domain,
     enable_starttls_auto: Rails.application.secrets.smtp_starttls_auto,
     openssl_verify_mode: 'none',
-    ssl: true
   }
 
   if Rails.application.secrets.sendgrid

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -3,7 +3,7 @@
 Decidim.configure do |config|
   config.application_name = 'Decidim ERC APP'
 
-  config.mailer_sender = 'decidim@decideix.com'
+  config.mailer_sender = Rails.application.secrets.smtp_username
 
   # Change these lines to set your preferred locales
   config.default_locale = :ca

--- a/config/initializers/open_ssl.rb
+++ b/config/initializers/open_ssl.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+ctx= Net::SMTP.default_ssl_context
+ctx.min_version= OpenSSL::SSL::TLS1_2_VERSION 
+ctx.max_version= nil


### PR DESCRIPTION
Sadly Ruby and mail gem do not use TLS 1.2 by default. For security reasons, and because it is now the common minimum version for many email smtp services this PR sets the context to use this version.

As the mail gem does not have a way to configure the ssl version, we do it modifying the default ssl context. Further information here: https://github.com/mikel/mail/issues/659#issuecomment-301981538