### PR TITLE
Diff with `differ` gem in export emendations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,8 @@ gem "whenever"
 gem "figaro", ">= 1.1.1"
 gem "openssl"
 
+gem "differ"
+
 group :development, :test do
   gem "better_errors"
   gem "binding_of_caller"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -383,6 +383,7 @@ GEM
       actionmailer (>= 4.1.0)
       devise (>= 4.0.0)
     diff-lcs (1.4.4)
+    differ (0.1.2)
     diffy (3.4.0)
     doc2text (0.4.3)
       nokogiri (~> 1.11.1)
@@ -834,6 +835,7 @@ DEPENDENCIES
   decidim-term_customizer!
   deface
   delayed_job_active_record
+  differ
   faker (~> 1.8.4)
   figaro (>= 1.1.1)
   letter_opener_web (~> 1.3.0)

--- a/app/serializers/decidim/amendment_serializer.rb
+++ b/app/serializers/decidim/amendment_serializer.rb
@@ -43,11 +43,7 @@ module Decidim
     end
 
     def amendment_diff
-      Diffy::Diff.new(
-        "#{amendable.body.values.first}\n",
-        "#{emendation.body.values.first}\n",
-        allow_empty_diff: false
-      ).to_s(:text)
+      Differ.diff_by_word(emendation.body.values.first, amendable.body.values.first).format_as(:ascii)
     end
   end
 end


### PR DESCRIPTION
In order to be able to show diffs at word level the `differ` gem can be used.
It can be used, for example:
```
@diff = Differ.diff_by_word(@current, @original)
  # => "Epic {"lolcat" >> "wolfman"} fail!"
```

In this PR we will refactor the export of emendations.

New diff in CSV:

![Captura de pantalla de 2021-06-28 16-19-21](https://user-images.githubusercontent.com/75725233/123653015-16a56c80-d82d-11eb-8a31-f7fc46363f56.png)

