### PR TITLE
Remove amendment type in proposals

### DIFF
--- a/app/views/decidim/amendments/_edit_form_fields.html.erb
+++ b/app/views/decidim/amendments/_edit_form_fields.html.erb
@@ -15,12 +15,13 @@
     <% end %>
   <% end %>
 
-  <%= form.select(:amendment_type,
-                  amendment_types.map { |g| [g[:name], g[:key]] },
-                  selected: emendation&.amendment_type,
-                  label: t("decidim.amendments.type")) %>
-
   <% if amendable.component.settings.participatory_texts_enabled? %>
+    <%= form.select(:amendment_type,
+                    amendment_types.map { |g| [g[:name], g[:key]] },
+                    selected: emendation&.amendment_type,
+                    label: t("decidim.amendments.type")) %>
+
+    
     <%= form.select(:sectorial_commission, sectorial_commissions,
                     selected: emendation&.sectorial_commission,
                     label: t("decidim.amendments.sectorial_commissions_title")) %>

--- a/spec/system/amendments_wizard_spec.rb
+++ b/spec/system/amendments_wizard_spec.rb
@@ -162,13 +162,8 @@ describe "Amendment Wizard", type: :system do
             within ".new_amendment" do
               fill_in :amendment_emendation_params_title, with: title
               fill_in :amendment_emendation_params_body, with: body
-              find("#amendment_amendment_type").find(:xpath, "option[1]").select_option
               find("*[type=submit]").click
             end
-          end
-
-          it "emendation draft has amendment_type" do
-            expect(emendation_draft.amendment_type).to eq("add")
           end
 
           it "shows similar emendations only of the same scope" do
@@ -196,13 +191,8 @@ describe "Amendment Wizard", type: :system do
           within ".new_amendment" do
             fill_in :amendment_emendation_params_title, with: title
             fill_in :amendment_emendation_params_body, with: body
-            find("#amendment_amendment_type").find(:xpath, "option[1]").select_option
             find("*[type=submit]").click
           end
-        end
-
-        it "emendation draft has amendment_type" do
-          expect(emendation_draft.amendment_type).to eq("add")
         end
 
         it "show the phone_number field prefilled" do
@@ -222,8 +212,8 @@ describe "Amendment Wizard", type: :system do
             end
           end
 
-          it "last proposal has amendment_type" do
-            expect(Decidim::Proposals::Proposal.last.amendment_type).to eq("add")
+          it "last proposal has NOT amendment_type" do
+            expect(Decidim::Proposals::Proposal.last.amendment_type).to eq(nil)
           end
 
           it "last proposal has NOT sectorial_commission" do


### PR DESCRIPTION
- Remove amendment type field in proposals when participatory text are not enable.
![Captura de pantalla de 2021-12-22 08-35-51](https://user-images.githubusercontent.com/75725233/147073519-c2139c21-d7e7-4843-82f8-60bb94797e11.png)
