### PR TITLE
Set max length in excel exportation

### DIFF
--- a/app/serializers/decidim/amendment_serializer.rb
+++ b/app/serializers/decidim/amendment_serializer.rb
@@ -47,7 +47,7 @@ module Decidim
     def new_body
       body = emendation.body["ca"]
 
-      body = body.chars.each_slice(MAX_LENGTH).map(&:join).first + "</p>" if body.length >= MAX_LENGTH
+      body = body.truncate(MAX_LENGTH, escape: false) if body.length >= MAX_LENGTH
 
       body
     end


### PR DESCRIPTION
Excel supports a maximum of 32.767 characters per cell(https://support.microsoft.com/en-us/office/excel-specifications-and-limits-1672b34d-7043-467e-8e27-269d656771c3?ui=en-us&rs=en-us&ad=us#ID0EBABAAA=Excel_2016-2013) , the body in the export has been limited to this number of characters as the export was broken due to this.

